### PR TITLE
Cookies for IdP not cleared when deleteAllCookies() invoked

### DIFF
--- a/src/main/java/monitoring/eb/SamlProxyMonitor.java
+++ b/src/main/java/monitoring/eb/SamlProxyMonitor.java
@@ -25,7 +25,6 @@ public class SamlProxyMonitor implements Monitor {
         this.mujinaServiceProviderBaseUrl = mujinaServiceProviderBaseUrl;
         this.userName = userName;
         this.idpEntityId = idpEntityId;
-        driver = new HtmlUnitDriver(false);
     }
 
     @Override
@@ -39,7 +38,7 @@ public class SamlProxyMonitor implements Monitor {
     }
 
     private void doMonitor() {
-        driver.manage().deleteAllCookies();
+        driver = new HtmlUnitDriver(false);
 
         driver.get(mujinaServiceProviderBaseUrl + "/user.html");
 


### PR DESCRIPTION
This change will call a new HTML driver and ensure a clean slate on every health check.

The selenium documentation says that the `deleteAllCookies()` method only deletes the cookies from the last contacted domain. When the method is invoked, the IdP is not the last accessed domain, so the cookies are persistent and it's causing the issue I experienced here: https://groups.google.com/forum/#!topic/openconext/3lil5-SlRaQ 

The reason it works every other time, is that when a failure happens, the IdP is the last domain accessed. Then, once  `deleteAllCookies()` is invoked, the cookies for the IdP are deleted and the run is successful. This explains why running the health check after every service restart results in a success.